### PR TITLE
Implement Ollama thinking option

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -16,11 +16,11 @@ Adapt the project to be compatible with multiple LLM backends (Ollama, LM Studio
 - Added `config.yaml` and `config.py` to provide a unified configuration system with environment-variable overrides.
 - Enhanced `llm_factory.get_llm` to accept API keys and base URLs, addressing backend-specific differences.
 - Updated agent files to use `config.get_default_llm` for consistent configuration handling.
+- Added `ChatOllamaThinking` wrapper and configuration option to enable Ollama's thinking mode.
 
 ## Next Steps for Implementation
 
-1.  **Explore Ollama "Thinking Models":** Investigate how to leverage Ollama's "thinking models" feature, if relevant to the agent's workflow. This might involve specific prompting strategies or model configurations when using the Ollama backend.
-2.  **Comprehensive Testing:** Conduct thorough testing of the project with each implemented backend to ensure correct functionality and performance.
+1.  **Comprehensive Testing:** Conduct thorough testing of the project with each implemented backend to ensure correct functionality and performance.
 
 ## Instructions for the Next Agent
 

--- a/agents/llm_factory.py
+++ b/agents/llm_factory.py
@@ -4,7 +4,7 @@ from langchain_openai import ChatOpenAI
 # For example:
 from langchain_community.llms import HuggingFacePipeline
 from transformers import pipeline
-from langchain_community.chat_models import ChatOllama
+from .ollama_thinking import ChatOllamaThinking
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 def get_llm(backend: str, model_name: str, **kwargs):
@@ -33,8 +33,10 @@ def get_llm(backend: str, model_name: str, **kwargs):
     elif backend == 'ollama':
         # Requires Ollama to be installed and running, and the specified model pulled (e.g., 'ollama pull llama2').
         # You can customise the base_url via OLLAMA_HOST or `base_url` kwarg.
+        # Optionally enable thinking mode via the `think` kwarg or OLLAMA_THINK env variable.
         base_url = kwargs.pop("base_url", os.getenv("OLLAMA_HOST"))
-        return ChatOllama(model=model_name, base_url=base_url, **kwargs)
+        think = kwargs.pop("think", None)
+        return ChatOllamaThinking(model=model_name, base_url=base_url, think=think, **kwargs)
     elif backend == 'lmstudio':
         # Example implementation for LM Studio (OpenAI-compatible API)
         # Requires LM Studio to be running with an OpenAI-compatible server.

--- a/agents/ollama_thinking.py
+++ b/agents/ollama_thinking.py
@@ -1,0 +1,15 @@
+from typing import Optional, Dict, Any
+from langchain_community.chat_models import ChatOllama
+
+class ChatOllamaThinking(ChatOllama):
+    """Extension of ChatOllama that adds support for the `think` parameter."""
+
+    think: Optional[bool] = None
+
+    @property
+    def _default_params(self) -> Dict[str, Any]:
+        params = super()._default_params
+        if self.think is not None:
+            params = dict(params)
+            params["think"] = self.think
+        return params

--- a/config.py
+++ b/config.py
@@ -17,6 +17,11 @@ def load_config(path: str = "config.yaml") -> dict:
     llm.setdefault('google_api_key', os.getenv('GOOGLE_API_KEY'))
     llm.setdefault('hf_token', os.getenv('HF_TOKEN'))
     llm.setdefault('ollama_host', os.getenv('OLLAMA_HOST'))
+    think_env = os.getenv('OLLAMA_THINK')
+    if think_env is not None:
+        llm['think'] = think_env.lower() in ('1', 'true', 'yes')
+    else:
+        llm.setdefault('think', False)
     llm.setdefault('lmstudio_url', os.getenv('LMSTUDIO_API_URL', 'http://localhost:1234/v1'))
     return data
 
@@ -33,6 +38,8 @@ def get_default_llm(**kwargs):
     }
     if backend == 'lmstudio':
         options['base_url'] = llm_cfg.get('lmstudio_url')
-    if backend == 'ollama' and llm_cfg.get('ollama_host'):
-        options['base_url'] = llm_cfg['ollama_host']
+    if backend == 'ollama':
+        if llm_cfg.get('ollama_host'):
+            options['base_url'] = llm_cfg['ollama_host']
+        options['think'] = llm_cfg.get('think')
     return get_llm(backend=backend, model_name=model, temperature=llm_cfg.get('temperature', 0), **{**options, **kwargs})

--- a/config.yaml
+++ b/config.yaml
@@ -6,4 +6,5 @@ llm:
   google_api_key: ""
   hf_token: ""
   ollama_host: ""
+  think: false
   lmstudio_url: "http://localhost:1234/v1"


### PR DESCRIPTION
## Summary
- add ChatOllamaThinking wrapper to support the `think` parameter
- expose `think` configuration in `config.yaml`/`config.py`
- update `llm_factory.get_llm` to use the new wrapper
- document progress in `TASK.md`

## Testing
- `python -m py_compile agents/ollama_thinking.py agents/llm_factory.py config.py`
- `python - <<'PY'
from config import get_default_llm, load_config
cfg = load_config()
llm = get_default_llm()
print('backend', cfg['llm']['backend'])
print(type(llm))
PY` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*


------
https://chatgpt.com/codex/tasks/task_e_68407073cbbc83259be6507182885743